### PR TITLE
Added HTML escape for caption

### DIFF
--- a/jquery.fs.boxer.js
+++ b/jquery.fs.boxer.js
@@ -313,7 +313,7 @@ if (jQuery) (function($) {
 	// Format captions
 	function _formatCaption($target) {
 		var title = $target.attr("title");
-		return (title != "" && title !== undefined) ? '<p class="caption">' + title + '</p>' : "";
+		return (title != "" && title !== undefined) ? $('<p>').addClass('caption').text(title)[0].outerHTML : "";
 	}
 	
 	// Resize image to fit in viewport


### PR DESCRIPTION
caption is not added correctly, when title attribute have HTML tags.

ex. &lt;a href="image.jpg" class="boxer" title="&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;"&gt;
